### PR TITLE
Fikse brukket design på header, ta i bruk mer fra aksel, + småplukk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .yarn/install-state.gz
 
 .idea
+*.iml
 node_modules
 .cache
 dist

--- a/packages/aap-felles-css/src/kelvin-app-header.css
+++ b/packages/aap-felles-css/src/kelvin-app-header.css
@@ -1,38 +1,15 @@
-.kelvin-app-header {
-  display: flex;
-  flex-direction: column;
-}
-.kelvin-app-header-link {
+.kelvin-app-header-link,
+.kelvin-app-header-search-result p,
+.kelvin-app-header-search-result label,
+.kelvin-app-header-search-result .navds-heading {
   color: var(--a-white);
 }
-.kelvin-app-main-header {
-  display: flex;
-  justify-content: space-between;
-  max-height: 4rem;
-  width: 100%;
-}
-.kelvin-app-main-header-borderBottom {
-  border-bottom: 1px solid grey; //TODO: riktig farge
-}
 
-.kelvin-app-header-leftSide {
-  display: flex;
-  flex-direction: row;
-  gap: var(--a-spacing-4);
-}
-
-.kelvin-app-header-link {
-  width: 100%;
+.kelvin-app-header-search-result {
+  border-top: 1px solid var(--a-gray-50);
 }
 
 .kelvin-oppgavesok-form {
   padding-top: var(--a-spacing-2);
   background-color: var(--a-surface-inverted);
-}
-
-.kelvin-oppgavesok-resultat {
-  background-color: var(--a-surface-inverted);
-  list-style: none;
-  padding: 0;
-  margin: 0;
 }

--- a/packages/aap-felles-react/src/KelvinAppHeader/KelvinAppHeader.tsx
+++ b/packages/aap-felles-react/src/KelvinAppHeader/KelvinAppHeader.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import React, {useState} from 'react';
-import {Button, Dropdown, HStack, InternalHeader, Link, VStack} from '@navikt/ds-react';
-import { Kelvinsøk, SøkeResultat} from './Kelvinsøk';
-import {Kelvinsøkeresultat} from "./Kelvinsøkeresultat";
+import React, { useState } from 'react';
+import { Box, Button, Dropdown, Heading, HStack, InternalHeader, Link, Spacer, VStack } from '@navikt/ds-react';
+import { Kelvinsøk, SøkeResultat } from './Kelvinsøk';
+import { LeaveIcon, XMarkIcon } from '@navikt/aksel-icons';
+import { Kelvinsøkeresultat } from "./Kelvinsøkeresultat";
+
 interface BrukerInformasjon {
   navn: string;
   NAVident?: string;
@@ -15,47 +17,66 @@ const Brukermeny = ({ brukerInformasjon }: { brukerInformasjon: BrukerInformasjo
     <Dropdown.Menu>
       <Dropdown.Menu.List>
         <Dropdown.Menu.List.Item>
-          <Link href={'/oauth2/logout'} className="kelvin-app-header-link">
-            Logg ut
-          </Link>
+          <Link href={'/oauth2/logout'}>Logg ut</Link>
+          <Spacer />
+          <LeaveIcon aria-hidden fontSize="1.5rem" />
         </Dropdown.Menu.List.Item>
       </Dropdown.Menu.List>
     </Dropdown.Menu>
   </Dropdown>
 );
+
 export const KelvinAppHeader = ({ brukerInformasjon }: { brukerInformasjon: BrukerInformasjon }) => {
   const [søkeresultat, setSøkeresultat] = useState<SøkeResultat | undefined>(undefined);
+
   return (
-    <InternalHeader className="kelvin-app-header">
-      <div className={`kelvin-app-main-header ${søkeresultat ? 'kelvin-app-main-header-borderBottom' : ''}`}>
-        <div className="kelvin-app-header-leftSide">
-          <InternalHeader.Title href="/">Kelvin</InternalHeader.Title>
-          <Kelvinsøk setSøkeresultat={setSøkeresultat}/>
-          <Link className="kelvin-app-header-link" href={`/oppgave/`}>
+    <>
+      <InternalHeader>
+        <InternalHeader.Title href="/">Kelvin</InternalHeader.Title>
+
+        <HStack gap="4" marginInline="4">
+          <Kelvinsøk setSøkeresultat={setSøkeresultat} />
+          <Link href={`/oppgave/`} className="kelvin-app-header-link">
             Oppgaveliste
           </Link>
-          <Link className="kelvin-app-header-link" href={`/oppgave/produksjonsstyring`}>
+          <Link href={`/oppgave/produksjonsstyring`} className="kelvin-app-header-link">
             Produksjonsstyring
           </Link>
-          <Link className="kelvin-app-header-link" href={`/saksbehandling/saksoversikt`}>
+          <Link href={`/saksbehandling/saksoversikt`} className="kelvin-app-header-link">
             Saksoversikt
           </Link>
-          <Link className="kelvin-app-header-link" href={`/postmottak/`}>
+          <Link href={`/postmottak/`} className="kelvin-app-header-link">
             Postmottak
           </Link>
-          <Link className="kelvin-app-header-link" href={`/saksbehandling/sanity`}>
+          <Link href={`/saksbehandling/sanity`} className="kelvin-app-header-link">
             Sanity
           </Link>
-        </div>
-        <Brukermeny brukerInformasjon={brukerInformasjon}/>
-      </div>
-      {søkeresultat && <VStack padding={'2'}>
-          <HStack justify={'space-between'} >
-              <p>Søkeresultater</p>
-              <Button variant={'secondary'} size={'small'} onClick={() => setSøkeresultat(undefined)}>Lukk</Button>
-          </HStack>
-          <Kelvinsøkeresultat søkeresultat={søkeresultat}/>
-      </VStack>}
-    </InternalHeader>
+        </HStack>
+
+        <Spacer />
+        <Brukermeny brukerInformasjon={brukerInformasjon} />
+      </InternalHeader>
+
+      {søkeresultat && (
+        <Box background="surface-inverted" className="kelvin-app-header-search-result">
+          <VStack padding="4">
+            <HStack justify={'space-between'}>
+              <Heading size="small" spacing>Søkeresultater</Heading>
+              <Button
+                variant={'primary-neutral'}
+                size={'small'}
+                icon={<XMarkIcon />}
+                onClick={() => setSøkeresultat(undefined)}
+              >
+                Lukk
+              </Button>
+            </HStack>
+
+            <Kelvinsøkeresultat søkeresultat={søkeresultat} />
+          </VStack>
+        </Box>
+      )}
+
+    </>
   );
 }

--- a/packages/aap-felles-react/src/KelvinAppHeader/Kelvinsøkeresultat.tsx
+++ b/packages/aap-felles-react/src/KelvinAppHeader/Kelvinsøkeresultat.tsx
@@ -1,41 +1,39 @@
 'use client'
 
-import {HStack, Label} from "@navikt/ds-react";
+import { Detail, HStack, Label, Link, VStack } from "@navikt/ds-react";
 import React from "react";
-import {SøkeResultat} from "./Kelvinsøk";
+import { SøkeResultat } from "./Kelvinsøk";
 
 interface Props {
   søkeresultat: SøkeResultat
 }
-export const Kelvinsøkeresultat = ({søkeresultat}: Props) => {
-  return (
-    <section>
-      <HStack gap={'4'}>
-        {(søkeresultat?.saker && søkeresultat?.saker.length > 0) && (<div>
-          <Label>Saker</Label>
-          <ul className={'kelvin-oppgavesok-resultat'}>
-            {søkeresultat.saker.map((søk, index) => (
-              <li key={`saker-resultat-${index}`}>
-                <a
-                  href={søk.href}
-                >{søk.label}</a>
-              </li>
-            ))}
-          </ul>
-        </div>)}
-        {(søkeresultat?.oppgaver && søkeresultat?.oppgaver.length > 0) && (<div>
-          <Label>Oppgaver</Label>
-          <ul className={'kelvin-oppgavesok-resultat'}>
-            {søkeresultat.oppgaver.map((søk, index) => (
-              <li key={`oppgaver-resultat-${index}`}>
-                <a
-                  href={søk.href}
-                >{søk.label}</a>
-              </li>
-            ))}
-          </ul>
-        </div>)}
-      </HStack>
-    </section>
-  )
-}
+
+export const Kelvinsøkeresultat = ({ søkeresultat: { oppgaver, saker } }: Props) => (
+  <HStack gap={'8'}>
+    <div>
+      <Label spacing>Saker</Label>
+      <VStack gap="2">
+        {!saker?.length ? (
+          <Detail>Fant ingen saker</Detail>
+        ) : (
+          saker.map((søk, index) => (
+            <Link key={`sak-resultat-${index}`} href={søk.href}>{søk.label}</Link>
+          ))
+        )}
+      </VStack>
+    </div>
+
+    <div>
+      <Label spacing>Oppgaver</Label>
+      <VStack gap="2">
+        {!oppgaver?.length ? (
+          <Detail>Fant ingen saker</Detail>
+        ) : (
+          oppgaver.map((søk, index) => (
+            <Link key={`oppgave-resultat-${index}`} href={søk.href}>{søk.label}</Link>
+          ))
+        )}
+      </VStack>
+    </div>
+  </HStack>
+)


### PR DESCRIPTION
Ser sånn ut i dev nå: 

![Screenshot 2025-03-05 at 11 53 01](https://github.com/user-attachments/assets/ac7fa0f7-bdb4-4252-8461-e1b81921ed5d)


Bruker aksel for å sikre spacing, m.m. 
La også til litt bedre info i tilfeller hvor saksbehandler ikke får noen resultater på søket. 

![Screenshot 2025-03-06 at 11 12 35](https://github.com/user-attachments/assets/2d7bdf27-7fbe-429c-be34-a53a3bd7e4e5)
